### PR TITLE
Adding Slack and Email list link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,6 @@ pip install grai-source-dbt
 
 ## Community
 
-More to come here but if you're interested in contributing or just want to chat, drop an email to hello@grai.io.
+Come and join our [Slack](https://join.slack.com/t/graicommunity/shared_invite/zt-1il70kfeb-TaCm5fwHg_quWCpKNYyj6w)! We're on hand for support, help or just to hang out and chat.
 
-Or join our [discord](https://discord.gg/eZfYjfWWwB)!
+To stay looped into updates, join our [email list](https://www.grai.io/signup/).


### PR DESCRIPTION
- Adding slack community link to readme
- Adding direct email list link to readme