### PR TITLE
Only run server-image-build when files have changed

### DIFF
--- a/.github/workflows/server-image-build.yml
+++ b/.github/workflows/server-image-build.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - ".github/workflows/server-image-build.yml"
+      - "grai-server/**"
   # Compare the last commit of main -> to the current commit of a PR branch.
   # (Note: To compare changes between the last pushed commit to the remote PR branch set `since_last_remote_commit: true`)
   pull_request:

--- a/.github/workflows/server-image-build.yml
+++ b/.github/workflows/server-image-build.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - ".github/workflows/server-image-build.yml"
+      - "grai-server/**"
 
 env:
   dockerfile_path: ./grai-server/app
@@ -21,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0  # OR "2" -> To retrieve the preceding commit.
+          fetch-depth: 0 # OR "2" -> To retrieve the preceding commit.
 
       - name: Get changed files in grai-server
         id: changed-files-specific


### PR DESCRIPTION
I probably want to delete this workflow in favour of review-app, but for now we can run it only when grai-server files change