### PR TITLE
feat: Uffizzi Preview Environments for PRs 

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,143 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, review_requested]
+
+jobs:
+
+  build-server:
+    name: Build and push `grai-server`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ttl.sh/${{ env.UUID_WORKER }}
+          tags: type=raw,value=60d
+      
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./grai-server/app
+          file: ./grai-server/app/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  build-frontend:
+    name: Build and push `grai-frontend`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ttl.sh/${{ env.UUID_WORKER }}
+          tags: type=raw,value=60d
+      
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./grai-frontend
+          file: ./grai-frontend/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-server
+      - build-frontend
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          SERVER_IMAGE=${{ needs.build-server.outputs.tags }}
+          FRONTEND_IMAGE=${{needs.build-frontend.outputs.tags}}
+          export SERVER_IMAGE FRONTEND_IMAGE
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          GHA_ACTOR=${{github.actor}}
+          GHA_REPO=${{github.event.repository.name}}
+          GHA_BRANCH=${{github.head_ref}}
+          export GHA_ACTOR GHA_REPO GHA_BRANCH
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,88 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs:
+      - cache-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,57 @@
+version: "3.7"
+
+x-uffizzi:
+  ingress:
+    service: nginx
+    port: 8081
+
+services:
+
+  server:
+    image: "${SERVER_IMAGE}"
+    volumes:
+      - ./grai-server/app/:/usr/src/app/
+    ports:
+      - 8000:8000
+    environment:
+      - DB_HOST=127.0.0.1
+      - DB_PORT=5432
+      - DB_NAME=grai
+      - DB_USER=grai
+      - DB_PASSWORD=grai
+      - DJANGO_SUPERUSER_USERNAME=null@grai.io
+      - DJANGO_SUPERUSER_PASSWORD=super_secret
+      - DJANGO_SUPERUSER_WORKSPACE=Workspace1
+    entrypoint: /bin/sh
+    command:
+         - "-c"
+         - "FRONTEND_URL=$$UFFIZZI_URL/ /usr/src/app/entrypoint.sh gunicorn the_guide.wsgi -b 127.0.0.1:8000 -w 2"
+    deploy:
+          resources:
+            limits:
+              memory: 2000M  
+  
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_USER=grai
+      - POSTGRES_PASSWORD=grai
+      - POSTGRES_DB=grai
+    ports:
+      - 5432:5432
+  
+  frontend:
+    image: "${FRONTEND_IMAGE}"
+    entrypoint: /bin/sh
+    command:
+         - "-c"
+         - "REACT_APP_SERVER_URL=$$UFFIZZI_URL/api /usr/share/nginx/html/env.sh && nginx -g \"daemon off;\""
+    deploy:
+          resources:
+            limits:
+              memory: 2000M  
+              
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx-uffizzi:/etc/nginx

--- a/nginx-uffizzi/nginx.conf
+++ b/nginx-uffizzi/nginx.conf
@@ -1,0 +1,23 @@
+error_log /var/log/nginx/error.log info;
+
+events {
+    worker_connections 1024; #default
+}
+http {
+
+    server {
+        listen 8081;
+
+        location / {
+            proxy_pass http://127.0.0.1:80/;
+            proxy_ssl_session_reuse off;
+            proxy_set_header Host $http_host;
+        }
+
+        location /api/ {
+            proxy_pass http://127.0.0.1:8000/;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $http_connection;
+        }
+    }
+}


### PR DESCRIPTION
This PR is adding support for preview environments for PR events (opened, sync'ed, reopened, etc), powered by [Uffizzi](https://www.uffizzi.com/).

### What does the PR contain?

This PR uses two GHA workflows — `uffizzi-build.yml` and `uffizzi-preview.yml` — to build and provision preview environments. This PR uses `grai-server Dockerfile` and `grai-frontend Dockerfile` to build `grai-server` and `grai-frontend` from source, ensuring changes are reflected in the preview environment. 

The `docker-compose.uffizzi.yml` defines 4 containers: `grai-server`, `grai-frontend`,  `postgres` for storage, and `nginx` to proxy requests into the server. This file also defines Uffizzi integration, which is an entry point into the `grai-frontend` container.

Once a PR event is triggered — PR opened, PR synced, review requested — the build workflow `(uffizzi-build.yml)` will build the containers defined in the `docker-compose.uffizzi.yml` file, and the preview workflow `(uffizzi-preview.yml)` will either spin up a new preview or update an existing preview. The previews are ephemeral — so they live for only as long as needed. A comment is posted on the PR containing the URL of the preview environment, allowing contributors and maintainers to easily navigate to the preview. 

Clicking the link posted on the comment will take the user to the preview. The preview comes will take users to the `sign-in` screen of `grai-frontend`. 

### How was the PR Tested?

To test this, I opened a [PR against my fork](https://github.com/ShrutiC-git/grai-core/pull/3) of `grai-core`. The `uffizzi-build.yml` file triggered the `Build PR Image` action post opening this PR. Once this action was completed, the `uffizzi-preview.yml` GHA-file triggered the `Deploy Preview` action. [This comment posted on the PR](https://github.com/ShrutiC-git/grai-core/pull/3#issuecomment-1404273093) takes me to the preview. This is the [preview environment](https://app.uffizzi.com/github.com/ShrutiC-git/grai-core/pull/3) for this PR. 

The preview environment took me to `grai-frontend's` login screen. The environment uses the following credentials to sign-in:
```
username: null@grai.io
password: super_secret
```
Looking forward to powering preview environments for `grai`. This PR is building `grai-frontend` and `grai-server` - curious to know how the community would be using previews. 

If there is anything that needs to be changed on this PR or any other questions/feedback/concerns, please do let me know. We will make the necessary changes to align with the grai-community's priorities and need!

 PS: _We use this 2-step workflow for open-source projects, to allow open-source projects to have previews for contributions from forks. [Here](https://www.uffizzi.com/preview-environments-guide/github-actions-two-stage-workflow) is a more in-depth read into why we use a two-stage workflow._
 
 cc @waveywaves