### PR TITLE
feature/gra-251-postgres-constraints-arent-always

### DIFF
--- a/grai-integrations/source-postgres/pyproject.toml
+++ b/grai-integrations/source-postgres/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "grai_source_postgres"
-version = "0.1.12"
+version = "0.1.13"
 description = ""
 authors = ["Ian Eaves <ian@grai.io>"]
 license = "Elastic-2.0"

--- a/grai-integrations/source-postgres/src/grai_source_postgres/base.py
+++ b/grai-integrations/source-postgres/src/grai_source_postgres/base.py
@@ -10,7 +10,7 @@ from grai_source_postgres.package_definitions import config
 
 
 def get_nodes_and_edges(connector: PostgresConnector, version: Literal["v1"]) -> Tuple[List[Node], List[Edge]]:
-    with connector.connect() as conn:
+    with connector as conn:
         nodes, edges = conn.get_nodes_and_edges()
 
     nodes = adapt_to_client(nodes, version)

--- a/grai-integrations/source-postgres/src/grai_source_postgres/loader.py
+++ b/grai-integrations/source-postgres/src/grai_source_postgres/loader.py
@@ -45,7 +45,8 @@ class PostgresConnector:
         self.password = password if password is not None else get_from_env("password")
         self.namespace = namespace if namespace is not None else get_from_env("namespace", "default")
 
-        # Combo allows a user to use the context manager
+        # Combo allows the connection manager to guarantee the connector returns to it's previous connection
+        # status after __exit__ is called.
         self._connection = None
         self._is_connected = False
 

--- a/grai-integrations/source-postgres/src/grai_source_postgres/models.py
+++ b/grai-integrations/source-postgres/src/grai_source_postgres/models.py
@@ -41,10 +41,12 @@ class ColumnID(ID):
 
 
 class ColumnConstraint(Enum):
-    primary_key = "PRIMARY KEY"
-    unique = "UNIQUE"
-    foreign_key = "FOREIGN KEY"
-    check = "CHECK"
+    primary_key = "p"
+    unique = "u"
+    foreign_key = "f"
+    check = "c"
+    trigger = "t"
+    exclusion = "x"
 
 
 UNIQUE_COLUMN_CONSTRAINTS = {ColumnConstraint.primary_key.value, ColumnConstraint.unique.value}


### PR DESCRIPTION
We've previously queried constraint information like column uniqueness from INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE see: https://github.com/grai-io/grai-core/blob/4d56ba5d492dd26ac71ea9cc4ef3da7b106f35bc/grai-integrations/source-postgres/src/grai_source_postgres/loader.py#L118

However, that table only returns results for tables owned by the authenticated user. As a result our ability to detect column metadata could fail in unexpected ways for the user. 