### PR TITLE
Uffizzi-patch: Fix 413 Request Entity Too Large Error in uffizzi-build.yml

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -28,7 +28,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ttl.sh/${{ env.UUID_WORKER }}
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
           tags: type=raw,value=60d
       
       - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
@@ -65,7 +65,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ttl.sh/${{ env.UUID_WORKER }}
+          images: registry.uffizzi.com/${{ env.UUID_WORKER }}
           tags: type=raw,value=60d
       
       - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
    </a>
 </p>
 
-## Introduction
+## Introduction - UFFIZZI TEST PR
 
 **Data lineage made simple.**
 Grai makes it easy to understand how your data relates across databases, warehouses, APIs and dashboards.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
    </a>
 </p>
 
-## Introduction - UFFIZZI TEST PR
+## Introduction
 
 **Data lineage made simple.**
 Grai makes it easy to understand how your data relates across databases, warehouses, APIs and dashboards.


### PR DESCRIPTION
ttl.sh throws 413 when pushing to the registry in the `uffizzi-build` workflow due to ttl.sh ingress rejecting larger layer.

Switch to using `registry.uffizzi.com`. Actions are tested, uffizzi-build is now passing with this change.

cc @ieaves 