### PR TITLE
Uffizzi PR: Add Celery to docker-compose.uffizzi.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="https://www.grai.io" title="Grai Homepage"> Website </a>
 </p>
 
-## Introduction - Uffizzi Fork
+## Introduction
 
 **Data lineage made simple.**
 Grai makes it easy to understand and test how your data relates across databases, warehouses, APIs and dashboards.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="https://www.grai.io" title="Grai Homepage"> Website </a>
 </p>
 
-## Introduction
+## Introduction - Uffizzi Fork
 
 
 **Data lineage made simple.**

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 ## Introduction
 
+
 **Data lineage made simple.**
 Grai makes it easy to understand and test how your data relates across databases, warehouses, APIs and dashboards.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 
 ## Introduction - Uffizzi Fork
 
-
 **Data lineage made simple.**
 Grai makes it easy to understand and test how your data relates across databases, warehouses, APIs and dashboards.
 

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -22,10 +22,9 @@ services:
       - DJANGO_SUPERUSER_USERNAME=null@grai.io
       - DJANGO_SUPERUSER_PASSWORD=super_secret
       - DJANGO_SUPERUSER_WORKSPACE=Workspace1
-    entrypoint: /bin/sh
-    command:
-         - "-c"
-         - "FRONTEND_URL=$$UFFIZZI_URL/ /usr/src/app/entrypoint.sh gunicorn the_guide.wsgi -b 127.0.0.1:8000 -w 2"
+      - SERVER_HOST=localhost
+      - CELERY_BROKER=redis://127.0.0.1:6379/0
+      - CELERY_BACKEND=redis://127.0.0.1:6379/0
     deploy:
           resources:
             limits:
@@ -38,7 +37,7 @@ services:
       - POSTGRES_PASSWORD=grai
       - POSTGRES_DB=grai
     ports:
-      - 5432:5432
+      - 5432:5432   
   
   frontend:
     image: "${FRONTEND_IMAGE}"
@@ -49,9 +48,73 @@ services:
     deploy:
           resources:
             limits:
-              memory: 2000M  
+              memory: 2000M 
+  
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"             
               
   nginx:
     image: nginx:alpine
     volumes:
       - ./nginx-uffizzi:/etc/nginx
+      
+  celery_worker:
+    image: "${SERVER_IMAGE}"
+    command: 
+    - "/start-celeryworker"
+    volumes:
+      - ./grai-server/app/:/usr/src/app/
+    environment:
+      - DB_HOST=127.0.0.1
+      - DB_PORT=5432
+      - DB_NAME=grai
+      - DB_USER=grai
+      - DB_PASSWORD=grai
+      - DJANGO_SUPERUSER_USERNAME=null@grai.io
+      - DJANGO_SUPERUSER_PASSWORD=super_secret
+      - DJANGO_SUPERUSER_WORKSPACE=Workspace1
+      - SERVER_HOST=localhost
+      - CELERY_BROKER=redis://127.0.0.1:6379/0
+      - CELERY_BACKEND=redis://127.0.0.1:6379/0
+      - SECRET_KEY="123456789" 
+    deploy:
+          resources:
+            limits:
+              memory: 2000M      
+  
+  celery_beat_worker:
+    image: "${SERVER_IMAGE}"
+    volumes:
+      - ./grai-server/app/:/usr/src/app/
+    environment:
+      - DB_HOST=127.0.0.1
+      - DB_PORT=5432
+      - DB_NAME=grai
+      - DB_USER=grai
+      - DB_PASSWORD=grai
+      - DJANGO_SUPERUSER_USERNAME=null@grai.io
+      - DJANGO_SUPERUSER_PASSWORD=super_secret
+      - DJANGO_SUPERUSER_WORKSPACE=Workspace1
+      - SERVER_HOST=localhost
+      - CELERY_BROKER=redis://127.0.0.1:6379/0
+      - CELERY_BACKEND=redis://127.0.0.1:6379/0
+      - SECRET_KEY="123456789" 
+    command: 
+    - "/start-celerybeat"
+    deploy:
+          resources:
+            limits:
+              memory: 2000M            
+
+  flower:
+    image: mher/flower
+    ports:
+      - 5557:5555
+    environment:
+      - CELERY_BROKER_URL=redis://127.0.0.1:6379/0
+    deploy:
+          resources:
+            limits:
+              memory: 500M   

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -53,7 +53,11 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"             
+      - "6379:6379" 
+    deploy:
+          resources:
+            limits:
+              memory: 500M             
               
   nginx:
     image: nginx:alpine
@@ -117,4 +121,4 @@ services:
     deploy:
           resources:
             limits:
-              memory: 500M   
+              memory: 2000M   

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -64,7 +64,7 @@ services:
     volumes:
       - ./nginx-uffizzi:/etc/nginx
       
-  celery_worker:
+  celery-worker:
     image: "${SERVER_IMAGE}"
     command: 
     - "/start-celeryworker"
@@ -88,7 +88,7 @@ services:
             limits:
               memory: 2000M      
   
-  celery_beat_worker:
+  celery-beat-worker:
     image: "${SERVER_IMAGE}"
     volumes:
       - ./grai-server/app/:/usr/src/app/


### PR DESCRIPTION
Add celery and other needed dependencies in docker-compose.uffizzi.yml. 

With these dependencies added, jobs that were always stuck in the "queued" phase can move from the queue and be executed.