### PR TITLE
Feelback integration

### DIFF
--- a/docs/components/Feedback.tsx
+++ b/docs/components/Feedback.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useRouter } from "next/router";
+import { FeelbackTaggedMessage, PRESET_LIKE_DISLIKE } from "@feelback/react";
+
+export function FeedbackComponent({ contentSetId }: { contentSetId: string }) {
+  const router = useRouter();
+
+  return (
+    <div className="feedback-wrap nx-border-t nx-pt-8 dark:nx-border-neutral-800 contrast-more:nx-border-neutral-400 dark:contrast-more:nx-border-neutral-400 print:nx-hidden">
+      <FeelbackTaggedMessage key={router.route} // trick to reset state on page change
+        contentSetId={contentSetId}
+        layout="reveal-message"
+        style="width-sm"
+        preset={PRESET_LIKE_DISLIKE}
+        title="Did this doc help you?"
+        placeholder="Type the details (optional)"
+        withEmail
+        revokable={false}
+        slots={{
+          BeforeMessage: <p className="nx-text-xs nx-mt-4">Let us know the details</p>,
+          BeforeEmail: <p className="nx-text-xs nx-mt-2">If we can contact you with more questions, please enter your email address</p>
+        }}
+      />
+    </div>
+  )
+}

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@feelback/react": "^0.3.4",
         "@mendable/search": "^0.0.104",
         "@sentry/nextjs": "^7.48.0",
         "next": "^13.3.0",
@@ -300,6 +301,25 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@feelback/js": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@feelback/js/-/js-0.3.4.tgz",
+      "integrity": "sha512-xr7gTqSJcVUYQlELs1TntYovCBjMcYUr/hGKTnDoF64/lig5CbX4bOmqLoF50IImCy5q3oIwg9w+TSFvtBwsIA=="
+    },
+    "node_modules/@feelback/react": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@feelback/react/-/react-0.3.4.tgz",
+      "integrity": "sha512-ZWzUQAmPwl4nYR2olzBKddHzoLtGW/2pb8TiesiJCirxhaDW2E/XBx2ZaB4fL5TGXtjBt4eYq/qZxJZ0fIE0kg==",
+      "dependencies": {
+        "@feelback/js": "0.3.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      }
     },
     "node_modules/@headlessui/react": {
       "version": "1.7.15",

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "url": "git+https://github.com/grai-io/grai-core"
   },
   "dependencies": {
+    "@feelback/react": "^0.3.4",
     "@mendable/search": "^0.0.104",
     "@sentry/nextjs": "^7.48.0",
     "next": "^13.3.0",

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { DefaultSeo } from "next-seo";
 import SEO from "../next-seo.config";
+import "../styles.css";
 
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,3 +1,4 @@
+/*
 :root {
   --shiki-color-text: #414141;
   --shiki-color-background: transparent;
@@ -23,4 +24,74 @@
   --shiki-token-string-expression: #4bb74a;
   --shiki-token-punctuation: #bbbbbb;
   --shiki-token-link: #ffab70;
+}
+*/
+
+@import "@feelback/react/styles/feelback.css";
+
+.feelback-container {
+
+  .feelback-q {
+    font-size: 1.1em;
+
+    .feelback-btn {
+      --highlight-opacity: 0.07;
+      font-size: 1.4rem;
+      margin-top: 2px;
+
+      &:nth-child(1).active {
+        color: hsl(var(--nextra-primary-hue)100% 45%/var(--tw-text-opacity));
+        background-color: hsl(var(--nextra-primary-hue)100% 66%/.1);
+      }
+
+      &:nth-child(2).active {
+        color: hsl(315 100% 45%/var(--tw-text-opacity));
+        background-color: hsl(var(--nextra-primary-hue)100% 66%/.1);
+      }
+    }
+  }
+
+  .form-buttons {
+    margin-top: 0.5rem;
+
+    .btn-action {
+      font-weight: bold;
+      padding: 0.4rem 2rem;
+      height: auto;
+
+      &:hover {
+        color: hsl(var(--nextra-primary-hue)100% 45%/var(--tw-text-opacity));
+        background-color: hsl(var(--nextra-primary-hue)100% 66%/.1);
+      }
+    }
+  }
+}
+
+.feelback-container textarea,
+.feelback-container [type="email"] {
+  border: 1px solid rgb(183 184 186);
+}
+
+.feelback-container textarea:focus-visible {
+  outline: none;
+  --tw-ring-color: hsl(var(--nextra-primary-hue)100% 86%/var(--tw-ring-opacity));
+  --tw-ring-offset-color: hsl(var(--nextra-primary-hue)100% 77%);
+  --tw-ring-opacity: 1;
+  --tw-ring-offset-width: 1px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset)0 0 0 var(--tw-ring-offset-width)var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset)0 0 0 calc(2px + var(--tw-ring-offset-width))var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 transparent);
+}
+
+html.dark {
+
+  .feelback-container textarea,
+  input[type="email"] {
+    border: none;
+  }
+
+  .feelback-container textarea:focus-visible {
+    --tw-ring-color: hsl(var(--nextra-primary-hue)100% 32%/var(--tw-ring-opacity));
+    --tw-ring-offset-color: hsl(var(--nextra-primary-hue)100% 39%);
+  }
 }

--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -4,6 +4,7 @@ import { DocsThemeConfig, useConfig } from "nextra-theme-docs";
 import { useRouter } from "next/router";
 import HeaderLogo from "./components/HeaderLogo";
 import { Slack, Github } from "./components/Social";
+import { FeedbackComponent } from "./components/Feedback";
 
 const config: DocsThemeConfig = {
   project: {
@@ -39,6 +40,14 @@ const config: DocsThemeConfig = {
   logo: HeaderLogo,
   logoLink: "https://www.grai.io",
 
+  main: ({ children }) => {
+    return (
+      <>
+        {children}
+        <FeedbackComponent contentSetId="e05b4f9f-0f68-4a1c-bcf3-5ceab9d4fa74" />
+      </>
+    );
+  },
   sidebar: {
     defaultMenuCollapseLevel: 1,
   },


### PR DESCRIPTION
Hi, I had a brief exchange with @ieaves .
This PR integrates a feedback system for the docs website using [Feelback](https://www.feelback.dev/case/documentation). I opted for something similar to GitHub docs.
| light | dark|
|----|---|
| ![image](https://github.com/grai-io/grai-core/assets/7147291/8493cf98-38f8-4404-b4dd-50e15f643d64) | ![image](https://github.com/grai-io/grai-core/assets/7147291/3c01a295-07c0-466d-8d17-49e17968bb9d) |
| ![image](https://github.com/grai-io/grai-core/assets/7147291/77cb75a0-7258-44a9-8326-c4a2818f213a) | ![image](https://github.com/grai-io/grai-core/assets/7147291/6019172f-91c3-4ce7-a6c0-539fc041dd3d)|


## What is Feelback and what it does?
- allows to collect structured feedback for each doc page
- it's totally static, so no script runs or get downloaded. It's just a very light React component that gets bundled.
- it offers a dashboard to explore aggregated data with sentiment analysis to track the content performance


## The integration is very simple
1) With nextra you can place naturally something after the Page navigation-links. This is the `theme.config.tsx`.
```tsx
  main: ({ children }) => {
    return (
      <>
        {children}
        <FeedbackComponent contentSetId="e05b4f9f-0f68-4a1c-bcf3-5ceab9d4fa74" />
      </>
    );
  },
```
2) The `FeedbackComponent` just includes a builtin react component provided by the Feelback SDK.
3) the style.css includes some custom CSS to blend the feedback component with the doc style and colors. **N.B** I commented the previous `style.css` content as it was not used, maybe a leftover.

## Configuration
### External Required
The only external configuration required is the `contentSetId` I hard-coded in the theme file. It points to the _bucket_ where all feedback will be sent.

### Control appearance and features
The FeedbackComponent includes many props that can be tweaked, such as labels, make the email required, etc...

By default, if a user (device-based) sends multiple feedbacks for the same page, the last one "wins". In other words, the user can _edit_ the previous feedback with a new one. This is limited for a 15min window. After that, the feedback counts as a new one. (So while testing it locally, with multiple submissions, the feedback count will be 1, as it will get updated). This behavior can be disabled with the flag `revokable={false}`.

## What's missing
- I'm working on weekly/monthly mail recaps. So you don't have to hop on the dashboard.
- At the moment a Github integration is not yet ready. I mean, a feedback arrives, a issue or similar is created with some labels. But, to be honest, I would like to gate this to "premium-paid" plans.

## How to proceed from here
I already setup a Feelback account for Grai, with the configurations needed. The free plan has large limits.
If you like the system and want to use Feelback, I can handover the ownership of the account to one of you, and be available for support if needed.

Of course, I'm available to answer to any issue or request you may have.